### PR TITLE
feat: customize with ini file

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,4 @@
+[settings]
+startup = no
+trayicon = yes
+hotkey = alt+`


### PR DESCRIPTION
Use `windows-switcher.ini` file to customize the behaviour.

```
[settings]
startup = no
trayicon = yes
hotkey = alt+`
```

- `startup: yes/no` whether enable run on startup
- `trayicon: yes/no` whether show trayicon
- ``hotkey: alt+` `` Customize hotkey

> The `windows-switcher.ini` file should be placed in the same directory as `windows-switcher.exe`